### PR TITLE
Fix grammar in extension description

### DIFF
--- a/marketplaces/mozilla/description.html
+++ b/marketplaces/mozilla/description.html
@@ -38,7 +38,7 @@ Sending links to your past self isn't possible yet, but could come in a future v
   <li>Avoid time paradoxes.</li>
 </ul>
 
-<strong>How does it works?</strong>
+<strong>How does it work?</strong>
 It basically rely on an internal time vortex to send the links. See the <a href="https://github.com/maxlath/time-capsule">code</a> for more details.
 
 <strong>See also</strong>


### PR DESCRIPTION
I would also recommend changing the `<strong>` headings to use an actual heading tag, say `<h3>` or below. Was it intentional not to use them?