### PR TITLE
Fix incorrect tooltip for "switch to new tab when opening" option

### DIFF
--- a/src/popup/AdvancedCapsuleEditor.svelte
+++ b/src/popup/AdvancedCapsuleEditor.svelte
@@ -205,7 +205,6 @@
 
   <label
     class="option-group input-group has-checkbox"
-    title={i18n('opt_out_from_regrouping_this_capsule')}
   >
     <input type="checkbox" bind:checked={openAsActiveTab}>
     <span>{i18n('open_single_capsule_as_active_tab')}</span>


### PR DESCRIPTION
This seems like it might have been a copy-paste error from the option above it.